### PR TITLE
Return plot object 

### DIFF
--- a/supervenn/_plots.py
+++ b/supervenn/_plots.py
@@ -329,3 +329,4 @@ def supervenn(sets, set_annotations=None, figsize=DEFAULT_FIGSIZE, side_plots=Tr
         plt.sca(axes[1, 1])
         side_plot([len(set_) for set_ in sets], [1] * len(sets), 'v', color=side_plot_color)
         plt.ylim(ylim)
+    return plt


### PR DESCRIPTION
Hi,
I used your package (very useful!) and I needed to retrieve the plot object so I can save it as a SVG file using matplotlib functions. I only needed to return the plot in _plotpy to do so. I think it could be useful to others.
This way I can use supervenn in scripts like this:

```py
from supervenn import supervenn
sets = [{1, 2, 3, 4}, {3, 4, 5}, {1, 6, 7, 8}]
labels = ["G1","G2","G3"]
sv_fig = supervenn(sets, labels, figsize=(10, 6), sets_ordering='minimize gaps')
sv_fig.savefig("test_sv.svg")
```

I hope this can be useful!